### PR TITLE
Fix css module being passed incorrect workspace file url

### DIFF
--- a/.changeset/silent-garlics-kneel.md
+++ b/.changeset/silent-garlics-kneel.md
@@ -1,0 +1,5 @@
+---
+'snowpack': patch
+---
+
+Fix css module being passed incorrect workspace file url

--- a/snowpack/src/build/build-pipeline.ts
+++ b/snowpack/src/build/build-pipeline.ts
@@ -5,6 +5,7 @@ import {validatePluginLoadResult} from '../config';
 import {logger} from '../logger';
 import {PluginTransformResult, SnowpackBuildMap, SnowpackConfig} from '../types';
 import {getExtension, readFile, removeExtension} from '../util';
+import {getUrlsForFile} from './file-urls';
 import {cssModules, needsCSSModules} from './import-css';
 
 export interface BuildFileOptions {
@@ -108,6 +109,15 @@ async function runPipelineLoadStep(
           break;
         }
       }
+
+      if (config.workspaceRoot && srcPath.startsWith(config.workspaceRoot)) {
+        const urls = getUrlsForFile(srcPath, config);
+        const workspaceCssUrl = urls?.find((u) => u.endsWith('.css'));
+        if (workspaceCssUrl) {
+          url = workspaceCssUrl;
+        }
+      }
+
       const {css, json} = await cssModules({contents, url});
       result['.css'] = {...(result['.css'] || {}), code: css};
       result['.json'] = {code: JSON.stringify(json)};


### PR DESCRIPTION
## Changes

Fix for https://github.com/snowpackjs/snowpack/issues/3721

CSS Modules in a workspace packages were not using the correct output url
so the output classname json mapping was unable to be found, and then
defaulting to `{}`, so the styles weren't being applied.

## Testing

Tested against reproduction repository mentioned in #3721 

Started trying to add a test, but wasn't sure on the best way to proceed. Any pointers would be appreciated!

## Docs

Bugfix only
