### PR TITLE
use "knownEntrypoints" in common error help

### DIFF
--- a/docs/reference/common-error-details.md
+++ b/docs/reference/common-error-details.md
@@ -32,13 +32,13 @@ Our built-in TypeScript support can detect type-only imports and will attempt to
 
 This error could also appear if named imports are used with older, Common.js npm packages. Thanks to improvements in our package scanner this is no longer a common issue for most packages. However, some packages are written or compiled in a way that makes automatic import scanning impossible.
 
-**To solve:** Use the default import (`import pkg from 'my-old-package'`) for legacy Common.js/UMD packages that cannot be analyzed. Or, add the package name to your `packageOptions.namedExports` configuration for runtime import scanning.
+**To solve:** Use the default import (`import pkg from 'my-old-package'`) for legacy Common.js/UMD packages that cannot be analyzed. Or, add the package name to your `packageOptions.knownEntrypoints` configuration for runtime import scanning.
 
 ```js
 // snowpack.config.mjs
 export default {
   packageOptions: {
-    namedExports: ['@shopify/polaris-tokens'],
+    knownEntrypoints: ['@shopify/polaris-tokens'],
   },
 };
 ```


### PR DESCRIPTION
`packageOptions.namedExports` no longer exists (or never did) in [snowpack.config.mjs documentation](https://www.snowpack.dev/reference/configuration).
`packageOptions.knownEntrypoints` _does_ exist [in config documentation](https://www.snowpack.dev/reference/configuration#packageoptionsknownentrypoints) and solves the "does not provide an export named" error that the `packageOptions.namedExports`suggestion is used to help with in the **Uncaught SyntaxError: The requested module ‘./XXXXXX.js’ does not provide an export named ‘YYYYYY’** section of the **Common Error Details** page.

## Changes

Updates the [**Common Error Details**](https://www.snowpack.dev/reference/common-error-details#uncaught-syntaxerror-the-requested-module-xxxxxxjs-does-not-provide-an-export-named-yyyyyy) page to suggest using `packageOptions.knownEntrypoints`, which [is documented](https://www.snowpack.dev/reference/configuration#packageoptionsknownentrypoints), instead of using `packageOptions.namedExports` which is not documented.

### Before

![Screen Shot 2021-10-06 at 7 43 42 PM](https://user-images.githubusercontent.com/1205860/136307324-896add01-1f0b-4f75-a0e4-501b5c3799cd.png)

### After

![Screen Shot 2021-10-06 at 7 43 31 PM](https://user-images.githubusercontent.com/1205860/136307340-c2d978d6-abad-4c2c-abdf-a49bdf5edbbb.png)

## Testing

No tests added. This is just updating a tiny piece of documentation.

## Docs

A documentation update is the entirety of this pull request. [The **Uncaught SyntaxError: The requested module ‘./XXXXXX.js’ does not provide an export named ‘YYYYYY’** section of the **Common Error Details** page](https://www.snowpack.dev/reference/common-error-details#uncaught-syntaxerror-the-requested-module-xxxxxxjs-does-not-provide-an-export-named-yyyyyy) is being updated.
