### PR TITLE
fix: refactor verifyRequestBuilder to support multi-part  extensions

### DIFF
--- a/snowpack/src/build/file-builder.ts
+++ b/snowpack/src/build/file-builder.ts
@@ -20,6 +20,7 @@ import {
 } from '../types';
 import {
   createInstallTarget,
+  getPossibleExtensions,
   isRemoteUrl,
   relativeURL,
   removeLeadingSlash,
@@ -86,12 +87,20 @@ export class FileBuilder {
   }
 
   private verifyRequestFromBuild(type: string): SnowpackBuiltFile | undefined {
-    const possibleExtensions = this.urls.map((url) => path.extname(url));
-    if (!possibleExtensions.includes(type))
-      throw new Error(
-        `${this.loc} - Requested content "${type}" but only built ${possibleExtensions.join(', ')}`,
-      );
-    return this.resolvedOutput[type];
+    const possibleExtensions: string[] = [];
+
+    for (const url of this.urls) {
+      const urlExtensions = Array.from(getPossibleExtensions(url));
+      possibleExtensions.push(...urlExtensions);
+
+      if (urlExtensions.includes(type)) {
+        return this.resolvedOutput[type];
+      }
+    }
+
+    throw new Error(
+      `${this.loc} - Requested content "${type}" but only built ${possibleExtensions.join(', ')}`,
+    );
   }
 
   /**

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -385,25 +385,37 @@ export function findMatchingAliasEntry(
 }
 
 /**
+ * Get all the possible file extensions, from longest to shortest
+ */
+export function* getPossibleExtensions(fileName: string): Generator<string> {
+  let extensionMatchIndex = Math.max(0, fileName.lastIndexOf(path.sep));
+
+  do {
+    extensionMatchIndex = fileName.indexOf('.', extensionMatchIndex + 1);
+    if (extensionMatchIndex > -1) {
+      yield fileName.substr(extensionMatchIndex).toLowerCase();
+    }
+  } while (extensionMatchIndex > -1);
+}
+
+/**
  * Get the most specific file extension match possible.
  */
 export function getExtensionMatch(
   fileName: string,
   extensionMap: Record<string, string[]>,
 ): [string, string[]] | undefined {
-  let extensionPartial;
-  let extensionMatch;
-  // If a full URL is given, start at the basename. Otherwise, start at zero.
-  let extensionMatchIndex = Math.max(0, fileName.lastIndexOf('/'), fileName.lastIndexOf('\\'));
-  // Grab expanded file extensions, from longest to shortest.
-  while (!extensionMatch && extensionMatchIndex > -1) {
-    extensionMatchIndex++;
-    extensionMatchIndex = fileName.indexOf('.', extensionMatchIndex);
-    extensionPartial = fileName.substr(extensionMatchIndex).toLowerCase();
-    extensionMatch = extensionMap[extensionPartial];
+  const possibleExtensions = getPossibleExtensions(fileName);
+
+  for (const extension of possibleExtensions) {
+    if (extension in extensionMap) {
+      // Return the first match, if one was found.
+      return [extension, extensionMap[extension]];
+    }
   }
-  // Return the first match, if one was found. Otherwise, return undefined.
-  return extensionMatch ? [extensionPartial, extensionMatch] : undefined;
+
+  //Otherwise, return undefined.
+  return undefined;
 }
 
 export function isPathImport(spec: string): boolean {

--- a/snowpack/src/util.ts
+++ b/snowpack/src/util.ts
@@ -388,6 +388,7 @@ export function findMatchingAliasEntry(
  * Get all the possible file extensions, from longest to shortest
  */
 export function* getPossibleExtensions(fileName: string): Generator<string> {
+  // If a full URL is given, start at the basename. Otherwise, start at zero.
   let extensionMatchIndex = Math.max(0, fileName.lastIndexOf(path.sep));
 
   do {

--- a/test/snowpack/util.test.ts
+++ b/test/snowpack/util.test.ts
@@ -1,6 +1,19 @@
-const {getExtensionMatch} = require('../../snowpack/lib/cjs/util');
+const {getExtensionMatch, getPossibleExtensions} = require('../../snowpack/lib/cjs/util');
 
 const EMPTY = Buffer.from('');
+
+describe('getPossibleExtensions()', () => {
+  test('returns a Generator object', () => {
+    expect(getPossibleExtensions.constructor.name).toEqual('GeneratorFunction');
+  });
+
+  test('returns all the possible file extensions, from longest to shortest', () => {
+    expect([...getPossibleExtensions('foo')]).toEqual([]);
+    expect([...getPossibleExtensions('foo.js')]).toEqual(['.js']);
+    expect([...getPossibleExtensions('foo.one.js')]).toEqual(['.one.js', '.js']);
+    expect([...getPossibleExtensions('foo.one.two.js')]).toEqual(['.one.two.js', '.two.js', '.js']);
+  });
+});
 
 describe('getExtensionMatch()', () => {
   const TEST_EXTENSION_MAP = {


### PR DESCRIPTION
## Changes
Fixes #3411

Refactor `FileBuilder.verifyRequestFromBuild` method to check also for multi-part extensions.

For instance, given the following file structure:
```
src/components
├─ Button.js
├─ Button.styles.css
```
and given a plugin that transforms `.styles.css` files to `.styles.js`.
When calling `verifyRequestFromBuild`, it only checks for the shortest extension possible (`.js`), while instead it should check also multi-part extensions (`.styles.js`).

Running `snowpack dev` throws the following error:
```
Build Result Error: There was a problem with a file build result.
Error: [...]/snowpack-bug/src/components/Button.styles.css - Requested content ".styles.js" but only built .js
```

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

- Added unit tests to changed helper functions.
- Tested manually in local project:
    - Node.js 14 on Linux.
    - Node.js 14 on MacOS.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

## Docs
Bug fix only, no changes to docs required.
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
