### PR TITLE
Add "esnext" option to optimization target configuration

### DIFF
--- a/docs/guides/optimize-and-bundle.md
+++ b/docs/guides/optimize-and-bundle.md
@@ -40,7 +40,7 @@ export interface OptimizeOptions {
   treeshake: boolean;
   manifest: boolean;
   minify: boolean;
-  target: 'es2020' | 'es2019' | 'es2018' | 'es2017';
+  target: 'es2020' | 'es2019' | 'es2018' | 'es2017' | 'esnext';
 }
 ```
 

--- a/docs/guides/upgrade-guide.md
+++ b/docs/guides/upgrade-guide.md
@@ -62,7 +62,7 @@ export interface OptimizeOptions {
   treeshake: boolean;
   manifest: boolean;
   minify: boolean;
-  target: 'es2020' | 'es2019' | 'es2018' | 'es2017';
+  target: 'es2020' | 'es2019' | 'es2018' | 'es2017' | 'esnext';
 }
 ```
 

--- a/snowpack/src/types.ts
+++ b/snowpack/src/types.ts
@@ -228,7 +228,7 @@ export interface OptimizeOptions {
   treeshake: boolean;
   manifest: boolean;
   minify: boolean;
-  target: 'es2020' | 'es2019' | 'es2018' | 'es2017';
+  target: 'es2020' | 'es2019' | 'es2018' | 'es2017' | 'esnext';
 }
 
 export interface RouteConfigObject {


### PR DESCRIPTION
## Changes

Add the `esnext` option to optimization target, it is accepted by esbuild but was not present.
Related issue: #3840

## Testing

No tests added as this was only a type change.

## Docs

Type was added to docs.
